### PR TITLE
merging to version 0.4.4; bugfixes for QC

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GCLr
 Title: Genetic Analysis Tools
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: 
     person("Andy", "Barclay", , "andy.barclay@alaska.gov", role = c("aut", "cre"))
 Description: Genetic analysis tools to streamline genetic data analyses performed by Gene Conservation Lab (GCL) staff.

--- a/GCLr.Rproj
+++ b/GCLr.Rproj
@@ -15,3 +15,4 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## Bug fixes
+
+`dupcheck_qc_conflicts` - update to properly remove conflict fish that were lost in project or QC due to `remove_ind_miss_loci`.
+
+`qc_template()` - update directions to restart RStudio.
+
 # GCLr 0.4.3
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,10 @@
 
 `qc_template()` - update directions to restart RStudio.
 
+## Enhancements
+
+`loo_roc_rate_calc` - update to include *precision* - TP / (TP + FP) in the output.
+
 # GCLr 0.4.3
 
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# GCLr 0.4.4
+
 ## Bug fixes
 
 `dupcheck_qc_conflicts` - update to properly remove conflict fish that were lost in project or QC due to `remove_ind_miss_loci`.

--- a/R/dupcheck_qc_conflicts.R
+++ b/R/dupcheck_qc_conflicts.R
@@ -57,22 +57,22 @@ dupcheck_qc_conflicts <- function(conflicts, conflict_rate, project_sillys, Locu
       ind <- stringr::str_split(string = silly_ind, pattern = "_", simplify = TRUE)[, 2]
       
       # qc fish lost in QA?
-      if(ind %in% miss_loci_qc[[paste0(silly, "qc")]]){
+      if(ind %in% miss_loci_qc$IDs_Removed[[paste0(silly, "qc")]]){
         
         message(paste0("\n", silly, "qc_", ind," does not have at least 80% loci genotyped, not running DupCheck for this individual."))
         
       }  # print if any qc fish were removed due to missing genotypes
       
       # Project fish lost in QA
-      if(ind %in% MissLoci[[silly]]){
+      if(ind %in% MissLoci$IDs_Removed[[silly]]){
         
         message(paste0("\n", silly, "_", ind, " does not have at least 80% loci genotyped, not running DupCheck for this individual."))
         
       }  # print if any project fish were removed due to missing genotypes
       
-      paste(silly, ind, sep = "_")[!(ind %in% miss_loci_qc[[paste0(silly, "qc")]] | ind %in% MissLoci[[silly]])]  # Confirm qc fish and Project fish were not removed
+      paste(silly, ind, sep = "_")[!(ind %in% miss_loci_qc$IDs_Removed[[paste0(silly, "qc")]] | ind %in% MissLoci$IDs_Removed[[silly]])]  # Confirm qc fish and Project fish were not removed
       
-    })  # silly_ind
+    }) %>% unlist()  # silly_ind
     
     # If no more, stop
     

--- a/R/loo_roc_rate_calc.R
+++ b/R/loo_roc_rate_calc.R
@@ -20,9 +20,10 @@
 #'                \item \code{tn} (integer): number of true negative assignments
 #'                \item \code{tp} (integer): number of true positive assignments
 #'                \item \code{fp} (integer): number of false positive assignments
-#'                \item \code{tpr} (double): the true positive assignment rate
-#'                \item \code{fpt} (double): the false positive assignment rate
-#'                \item \code{acc} (double): accuracy rate
+#'                \item \code{tpr} (double): the true positive assignment rate - tp / (tp + fn)
+#'                \item \code{fpt} (double): the false positive assignment rate - fp / (fp + tn)
+#'                \item \code{acc} (double): accuracy rate - (tp + tn) / (tp + tn + fp + fn)
+#'                \item \code{pre} (double): precision rate - tp / (tp + fp)
 #'                \item \code{level} (double): the assignment threshold level (proportion)
 #'                \item \code{threshold} (character): the assignment threshold level (percent) for ROC curve plots.
 #'          }
@@ -94,9 +95,10 @@ loo_roc_rate_calc <- function(data, thres_levels, group_names, ncores = parallel
         
         counts %>%
           mutate(
-            tpr = tp / (tp + fn), # true positive rate (power)
+            tpr = tp / (tp + fn), # true positive rate (power; sensitivity)
             fpr = fp / (tn + fp), # false positive rate (type 1 error)
             acc = (tp + tn) / (tp + tn + fp + fn), # accuracy rate
+            pre = tp / (tp + fp), # precision rate (positive predictive value)
             level = ts
           ) # threshold level
         

--- a/inst/rmarkdown/templates/qc_template/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/qc_template/skeleton/skeleton.Rmd
@@ -35,7 +35,7 @@ The previous QC consisted of an R script with Excel and other outputs, this expo
 # Script Directions/Notes
     
     1) Add a title and your name to the top of the script.
-    2) Save this to the QC directory. Recommended naming convention: "project#_QC.Rmd". Example: S200_QC.Rmd
+    2) Save this to the QC directory and restart RStudio to set your working directory. Recommended naming convention: "project#_QC.Rmd". Example: S200_QC.Rmd
     3) Run this script in order, one code chunk at a time, or some functions will not provide accurate results. This is by design, as this script only hits LOKI once to save time.
     4) Add your review notes to the file (in the relevant project or QC review section), prior to finalizing (i.e., saving)!
 

--- a/man/loo_roc_rate_calc.Rd
+++ b/man/loo_roc_rate_calc.Rd
@@ -28,9 +28,10 @@ This function produces a tibble 10 variables:
 \item \code{tn} (integer): number of true negative assignments
 \item \code{tp} (integer): number of true positive assignments
 \item \code{fp} (integer): number of false positive assignments
-\item \code{tpr} (double): the true positive assignment rate
-\item \code{fpt} (double): the false positive assignment rate
-\item \code{acc} (double): accuracy rate
+\item \code{tpr} (double): the true positive assignment rate - tp / (tp + fn)
+\item \code{fpt} (double): the false positive assignment rate - fp / (fp + tn)
+\item \code{acc} (double): accuracy rate - (tp + tn) / (tp + tn + fp + fn)
+\item \code{pre} (double): precision rate - tp / (tp + fp)
 \item \code{level} (double): the assignment threshold level (proportion)
 \item \code{threshold} (character): the assignment threshold level (percent) for ROC curve plots.
 }


### PR DESCRIPTION
Just 1 minor bugfix to `dupcheck_qc_conflicts`. The previous version was not properly removing conflict fish that had dropped out due to missing loci (<80%) in the project or QC. This caused an issue for Jodi in S259QC, since all 3 conflict fish were dropped due to missing loci in the QC.