### PR TITLE
Bugfix `custom_comb_msgsi_output` P=0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: GCLr
 Title: Genetic Analysis Tools
-Version: 0.11.4
+Version: 0.11.5
 Authors@R: 
     person("Andy", "Barclay", , "andy.barclay@alaska.gov", role = c("aut", "cre"))
 Description: Genetic analysis tools to streamline genetic data analyses performed by Gene Conservation Lab (GCL) staff.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# GCLr 0.11.5
+
 ## Bug fixes
 
 `custom_comb_msgsi_output` - updated `P=0` calculation to divide by total harvest, not stock-specific harvest. This matches the updated in Ms.GSI v0.1.1.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## Bug fixes
+
+`custom_comb_msgsi_output` - updated `P=0` calculation to divide by total harvest, not stock-specific harvest. This matches the updated in Ms.GSI v0.1.1.
+
 # GCLr 0.11.4
 
 ## Bug fixes

--- a/R/custom_comb_msgsi_output.r
+++ b/R/custom_comb_msgsi_output.r
@@ -149,7 +149,7 @@ custom_comb_msgsi_output <- function(mdl_out = NULL,
         ci.05 = stats::quantile(value, 0.05),
         ci.95 = stats::quantile(value, 0.95),
         p0 = {if (is.null(harv)) mean(value < 5e-7)
-          else mean(value < (0.5/ max(1, harv * mean)))},
+          else mean(value < (0.5/ max(1, harv)))},
         .by = name
       ) %>%
       dplyr::mutate(


### PR DESCRIPTION
Updated `P=0` calculation to divide by total harvest, not stock-specific harvest. This matches the updated in Ms.GSI v0.1.1.